### PR TITLE
Fix for duration and length being null on newer maps

### DIFF
--- a/BeatSaverDownloader/Misc/BeatSaverAPIResult.cs
+++ b/BeatSaverDownloader/Misc/BeatSaverAPIResult.cs
@@ -34,8 +34,8 @@ namespace BeatSaverDownloader.Misc
     [Serializable]
     public class ParsedBeatmapDifficulty
     {
-        public int? duration = 0;
-        public int? length = 0;
+        public int duration = 0;
+        public int length = 0;
         public int bombs = 0;
         public int notes = 0;
         public int obstacles = 0;
@@ -48,8 +48,8 @@ namespace BeatSaverDownloader.Misc
         [JsonConstructor]
         public ParsedBeatmapDifficulty(int? duration, int? length, int bombs, int notes, int obstacles, float njs)
         {
-            this.duration = duration;
-            this.length = length;
+            this.duration = duration ?? 0;
+            this.length = length ?? 0;
             this.bombs = bombs;
             this.notes = notes;
             this.obstacles = obstacles;

--- a/BeatSaverDownloader/Misc/BeatSaverAPIResult.cs
+++ b/BeatSaverDownloader/Misc/BeatSaverAPIResult.cs
@@ -34,8 +34,8 @@ namespace BeatSaverDownloader.Misc
     [Serializable]
     public class ParsedBeatmapDifficulty
     {
-        public int duration = 0;
-        public int length = 0;
+        public int? duration = 0;
+        public int? length = 0;
         public int bombs = 0;
         public int notes = 0;
         public int obstacles = 0;
@@ -46,7 +46,7 @@ namespace BeatSaverDownloader.Misc
 
         }
         [JsonConstructor]
-        public ParsedBeatmapDifficulty(int duration, int length, int bombs, int notes, int obstacles, float njs)
+        public ParsedBeatmapDifficulty(int? duration, int? length, int bombs, int notes, int obstacles, float njs)
         {
             this.duration = duration;
             this.length = length;


### PR DESCRIPTION
Newer maps like https://beatsaver.com/beatmap/584a have duration and notes `null` instead of `0` and break the downloader because of that.

This is a quick and dirty fix, you can decline if lolpants fixes it on beatsaver's end.