### PR TITLE
Fix more songs not working if player settings is ever viewed

### DIFF
--- a/BeatSaverDownloader/UI/ViewControllers/DownloadQueueViewController.cs
+++ b/BeatSaverDownloader/UI/ViewControllers/DownloadQueueViewController.cs
@@ -34,9 +34,7 @@ namespace BeatSaverDownloader.UI.ViewControllers
                 SongDownloader.Instance.songDownloaded += SongDownloaded;
                 _songListTableCellInstance = Resources.FindObjectsOfTypeAll<LevelListTableCell>().First(x => (x.name == "LevelListTableCell"));
 
-                RectTransform viewControllersContainer = FindObjectsOfType<RectTransform>().First(x => x.name == "ViewControllers");
-
-                var headerPanelRectTransform = Instantiate(viewControllersContainer.GetComponentsInChildren<RectTransform>(true).First(x => x.name == "HeaderPanel" && x.parent.name == "PlayerSettingsViewController"), rectTransform);
+                var headerPanelRectTransform = Instantiate(Resources.FindObjectsOfTypeAll<PlayerSettingsViewController>().First().GetComponentsInChildren<RectTransform>(true).First(x => x.name == "HeaderPanel"), rectTransform);
                 headerPanelRectTransform.gameObject.SetActive(true);
 
                 _titleText = headerPanelRectTransform.GetComponentInChildren<TextMeshProUGUI>();


### PR DESCRIPTION
Currently if you the campaign is opened (this has the player settings on the left) or the player settings button on the main menu is clicked before more songs then it will not open properly. This fixes that by not relying on PlayerSettingsViewController to be a child of ViewConttrollers to fetch it.