### PR TITLE
Fixed breaking after settings apply

### DIFF
--- a/BeatSaverDownloader/BeatSaverDownloader.csproj
+++ b/BeatSaverDownloader/BeatSaverDownloader.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>BeatSaverDownloader</RootNamespace>
     <AssemblyName>BeatSaverDownloader</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+	<LangVersion>7.1</LangVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/BeatSaverDownloader/BeatSaverDownloader.csproj
+++ b/BeatSaverDownloader/BeatSaverDownloader.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>BeatSaverDownloader</RootNamespace>
     <AssemblyName>BeatSaverDownloader</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-	<LangVersion>7.1</LangVersion>
+    <LangVersion>7.1</LangVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/BeatSaverDownloader/UI/MoreSongsFlowCoordinator.cs
+++ b/BeatSaverDownloader/UI/MoreSongsFlowCoordinator.cs
@@ -14,11 +14,6 @@ namespace BeatSaverDownloader.UI
         private SongDescriptionViewController _songDescriptionView;
         private DownloadQueueViewController _downloadQueueView;
 
-        public static Action<BeatSaverSharp.Beatmap, Texture2D> didSelectSong;
-        public static Action<BeatSaverSharp.Beatmap, Texture2D> didPressDownload;
-        public static Action<BeatSaverSharp.User> didPressUploader;
-        public static Action filterDidChange;
-
         public void Awake()
         {
             if (_moreSongsView == null)
@@ -30,10 +25,10 @@ namespace BeatSaverDownloader.UI
                 _songDescriptionView = BeatSaberUI.CreateViewController<SongDescriptionViewController>();
                 _downloadQueueView = BeatSaberUI.CreateViewController<DownloadQueueViewController>();
 
-                didSelectSong += HandleDidSelectSong;
-                didPressDownload += HandleDidPressDownload;
-                filterDidChange += HandleFilterDidChange;
-                didPressUploader += HandleDidPressUploader;
+                _moreSongsView.didSelectSong += HandleDidSelectSong;
+                _moreSongsView.filterDidChange += HandleFilterDidChange;
+                _songDetailView.didPressDownload += HandleDidPressDownload;
+                _songDetailView.didPressUploader += HandleDidPressUploader;
             }
         }
 

--- a/BeatSaverDownloader/UI/ViewControllers/MoreSongsListViewController.cs
+++ b/BeatSaverDownloader/UI/ViewControllers/MoreSongsListViewController.cs
@@ -49,6 +49,9 @@ namespace BeatSaverDownloader.UI.ViewControllers
         public List<BeatSaverSharp.Beatmap> _songs = new List<BeatSaverSharp.Beatmap>();
         public LoadingControl loadingSpinner;
         internal Progress<Double> fetchProgress;
+        
+        public Action<BeatSaverSharp.Beatmap, Texture2D> didSelectSong;
+        public Action filterDidChange;
 
         public bool Working
         {
@@ -62,7 +65,7 @@ namespace BeatSaverDownloader.UI.ViewControllers
         [UIAction("listSelect")]
         internal void Select(TableView tableView, int row)
         {
-            MoreSongsFlowCoordinator.didSelectSong?.Invoke(_songs[row], customListTableData.data[row].icon);
+            didSelectSong?.Invoke(_songs[row], customListTableData.data[row].icon);
         }
         [UIAction("sortSelect")]
         internal async void SelectedSortOption(TableView tableView, int row)
@@ -73,7 +76,7 @@ namespace BeatSaverDownloader.UI.ViewControllers
             _currentBeatSaverFilter = filter.BeatSaverOption;
             _currentScoreSaberFilter = filter.ScoreSaberOption;
             ClearData();
-            MoreSongsFlowCoordinator.filterDidChange?.Invoke();
+            filterDidChange?.Invoke();
             await GetNewPage(2);
         }
         [UIAction("searchPressed")]
@@ -84,7 +87,7 @@ namespace BeatSaverDownloader.UI.ViewControllers
             _currentSearch = text;
             _currentFilter = FilterMode.Search;
             ClearData();
-            MoreSongsFlowCoordinator.filterDidChange?.Invoke();
+            filterDidChange?.Invoke();
             await GetNewPage(2);
         }
         [UIAction("abortClicked")]
@@ -102,7 +105,7 @@ namespace BeatSaverDownloader.UI.ViewControllers
             _currentFilter = FilterMode.BeatSaver;
             _currentBeatSaverFilter = BeatSaverFilterOptions.Uploader;
             ClearData();
-            MoreSongsFlowCoordinator.filterDidChange?.Invoke();
+            filterDidChange?.Invoke();
             await GetNewPage(2);
         }
         [UIAction("pageDownPressed")]

--- a/BeatSaverDownloader/UI/ViewControllers/SongDetailViewController.cs
+++ b/BeatSaverDownloader/UI/ViewControllers/SongDetailViewController.cs
@@ -37,6 +37,9 @@ namespace BeatSaverDownloader.UI.ViewControllers
         private TextMeshProUGUI _bombsText;
 
         private bool _downloadInteractable = false;
+        
+        public Action<BeatSaverSharp.Beatmap, Texture2D> didPressDownload;
+        public Action<BeatSaverSharp.User> didPressUploader;
 
         [UIValue("downloadInteractable")]
         public bool DownloadInteractable
@@ -62,6 +65,7 @@ namespace BeatSaverDownloader.UI.ViewControllers
         [UIAction("#post-parse")]
         internal void Setup()
         {
+            Console.WriteLine("AHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH");
             (transform as RectTransform).sizeDelta = new Vector2(70, 0);
             (transform as RectTransform).anchorMin = new Vector2(0.5f, 0);
             (transform as RectTransform).anchorMax = new Vector2(0.5f, 1);
@@ -72,12 +76,12 @@ namespace BeatSaverDownloader.UI.ViewControllers
         [UIAction("downloadPressed")]
         internal void DownloadPressed()
         {
-            MoreSongsFlowCoordinator.didPressDownload?.Invoke(_currentSong, _coverImage.texture as Texture2D);
+            didPressDownload?.Invoke(_currentSong, _coverImage.texture as Texture2D);
         }
         [UIAction("uploaderPressed")]
         internal void UploaderPressed()
         {
-            MoreSongsFlowCoordinator.didPressUploader?.Invoke(_currentSong.Uploader);
+            didPressUploader?.Invoke(_currentSong.Uploader);
         }
 
         internal void ClearData()


### PR DESCRIPTION
These static actions were never unsubscribed to so after a new menu scene was created the old ones that were destroyed get called. I fixed this by making them non-static and moving them to their respective ViewControllers.