### PR TITLE
Added ParentFlowCoordinator

### DIFF
--- a/BeatSaverDownloader/UI/MoreSongsFlowCoordinator.cs
+++ b/BeatSaverDownloader/UI/MoreSongsFlowCoordinator.cs
@@ -8,6 +8,7 @@ namespace BeatSaverDownloader.UI
 {
     public class MoreSongsFlowCoordinator : FlowCoordinator
     {
+        public FlowCoordinator ParentFlowCoordinator { get; set; }
         private NavigationController _moreSongsNavigationcontroller;
         private MoreSongsListViewController _moreSongsView;
         private SongDetailViewController _songDetailView;
@@ -148,8 +149,7 @@ namespace BeatSaverDownloader.UI
             }
             _moreSongsView.Cleanup();
             _downloadQueueView.AbortAllDownloads();
-            var mainFlow = BeatSaberMarkupLanguage.BeatSaberUI.MainFlowCoordinator;
-            mainFlow.DismissFlowCoordinator(this);
+            ParentFlowCoordinator.DismissFlowCoordinator(this);
         }
     }
 }

--- a/BeatSaverDownloader/UI/MoreSongsFlowCoordinator.cs
+++ b/BeatSaverDownloader/UI/MoreSongsFlowCoordinator.cs
@@ -8,7 +8,8 @@ namespace BeatSaverDownloader.UI
 {
     public class MoreSongsFlowCoordinator : FlowCoordinator
     {
-        public FlowCoordinator ParentFlowCoordinator { get; set; }
+        public FlowCoordinator ParentFlowCoordinator { get; protected set; }
+        public bool AllowFlowCoordinatorChange { get; protected set; } = true;
         private NavigationController _moreSongsNavigationcontroller;
         private MoreSongsListViewController _moreSongsView;
         private SongDetailViewController _songDetailView;
@@ -61,6 +62,15 @@ namespace BeatSaverDownloader.UI
                 Plugin.log.Error(ex);
             }
         }
+
+        public void SetParentFlowCoordinator(FlowCoordinator parent, bool allowChanges = false)
+        {
+            if (!AllowFlowCoordinatorChange)
+                throw new InvalidOperationException("Changing the parent FlowCoordinator is not allowed on this instance.");
+            ParentFlowCoordinator = parent;
+            AllowFlowCoordinatorChange = allowChanges;
+        }
+
         internal void UpdateTitle()
         {
             title = $"{_moreSongsView._currentFilter}";

--- a/BeatSaverDownloader/UI/PluginUI.cs
+++ b/BeatSaverDownloader/UI/PluginUI.cs
@@ -48,6 +48,7 @@ namespace BeatSaverDownloader.UI
         {
             if (_moreSongsFlowCooridinator == null)
                 _moreSongsFlowCooridinator = BeatSaberUI.CreateFlowCoordinator<MoreSongsFlowCoordinator>();
+            _moreSongsFlowCooridinator.ParentFlowCoordinator = BeatSaberMarkupLanguage.BeatSaberUI.MainFlowCoordinator;
             BeatSaberMarkupLanguage.BeatSaberUI.MainFlowCoordinator.PresentFlowCoordinator(_moreSongsFlowCooridinator); // ("PresentFlowCoordinator", _moreSongsFlowCooridinator, null, false, false);
         }
     }

--- a/BeatSaverDownloader/UI/PluginUI.cs
+++ b/BeatSaverDownloader/UI/PluginUI.cs
@@ -48,7 +48,7 @@ namespace BeatSaverDownloader.UI
         {
             if (_moreSongsFlowCooridinator == null)
                 _moreSongsFlowCooridinator = BeatSaberUI.CreateFlowCoordinator<MoreSongsFlowCoordinator>();
-            _moreSongsFlowCooridinator.ParentFlowCoordinator = BeatSaberMarkupLanguage.BeatSaberUI.MainFlowCoordinator;
+            _moreSongsFlowCooridinator.SetParentFlowCoordinator(BeatSaberMarkupLanguage.BeatSaberUI.MainFlowCoordinator, false);
             BeatSaberMarkupLanguage.BeatSaberUI.MainFlowCoordinator.PresentFlowCoordinator(_moreSongsFlowCooridinator); // ("PresentFlowCoordinator", _moreSongsFlowCooridinator, null, false, false);
         }
     }


### PR DESCRIPTION
I already worked around this by creating a child class of MoreSongsFlowCoordinator and some Reflection, but this would make it easier for other mods to add the Downloader's UI into their own (like adding a 'More Songs' button in Multiplayer's lobby) by being able to have Downloader's UI dismiss back to their own coordinator instead of the game's main one.