### PR TITLE
Fix version now

### DIFF
--- a/BeatSaverDownloader/Plugin.cs
+++ b/BeatSaverDownloader/Plugin.cs
@@ -34,13 +34,8 @@ namespace BeatSaverDownloader
         [OnStart]
         public void OnApplicationStart()
         {
-            string steamDllPath = Path.Combine(IPA.Utilities.UnityGame.InstallPath, "Beat Saber_Data", "Plugins", "steam_api64.dll");
-            bool hasSteamDll = File.Exists(steamDllPath);
-            string platform = hasSteamDll ? "steam" : "oculus";
-            string gameVersionFull = $"{IPA.Utilities.UnityGame.GameVersion.ToString()}-{platform}";
-
-            // fix version later
-            BeatSaver = new BeatSaverSharp.BeatSaver(new BeatSaverSharp.BeatSaverOptions("BeatSaber", new Version(1, 0, 0)));
+            var version = GetType().Assembly.GetName().Version;
+            BeatSaver = new BeatSaverSharp.BeatSaver(new BeatSaverSharp.BeatSaverOptions("BeatSaverDownloader", new Version(version.Major, version.Minor, version.Build)));
 
             instance = this;
             PluginConfig.LoadConfig();


### PR DESCRIPTION
Given how large a portion of beat saver traffic the downloader makes up it should probably be a good example and set a representative user agent.

Removed the old game version specifics, this can mostly be inferred and if desired should probably be moved upstream to beatsaversharp (I have a version of this locally but I'm not sure it's worth it personally)